### PR TITLE
Fixing bug to show span duration in milliseconds

### DIFF
--- a/lib/wavefrontopentracing/reporting/console.rb
+++ b/lib/wavefrontopentracing/reporting/console.rb
@@ -15,8 +15,8 @@ module Reporting
     def report(wavefront_span)
       line_data = Wavefront::WavefrontUtil.tracing_span_to_line_data(
         wavefront_span.operation_name,
-        (wavefront_span.start_time * 1000).to_i,
-        (wavefront_span.duration_time * 1000).to_i,
+        (wavefront_span.start_time.to_f * 1000).to_i,
+        wavefront_span.duration_time,
         @source,
         wavefront_span.trace_id,
         wavefront_span.span_id,

--- a/lib/wavefrontopentracing/reporting/wavefront.rb
+++ b/lib/wavefrontopentracing/reporting/wavefront.rb
@@ -29,8 +29,8 @@ module Reporting
     def report(wavefront_span)
       @sender.send_span(
         wavefront_span.operation_name,
-        (wavefront_span.start_time * 1000).to_i,
-        (wavefront_span.duration_time * 1000).to_i,
+        (wavefront_span.start_time.to_f * 1000).to_i,
+        wavefront_span.duration_time,
         @source,
         wavefront_span.trace_id,
         wavefront_span.span_id,

--- a/lib/wavefrontopentracing/span.rb
+++ b/lib/wavefrontopentracing/span.rb
@@ -14,7 +14,7 @@ module WavefrontOpentracing
     attr_reader :context
     # @return [String] provides span operation name
     attr_reader :operation_name
-    # @return [Integer] provides span start time
+    # @return [Time] provides span start time object
     attr_reader :start_time
     # @return [<UUID>] provides a list of UUID's of parents span
     attr_reader :parents
@@ -96,7 +96,7 @@ module WavefrontOpentracing
 
     # Call finish to finish current span, and report it.
     #
-    # @param end_time [Integer] finish time, unix timestamp.
+    # @param end_time [Time] finish time as Time.now().
     def finish(end_time = nil)
       if !end_time.nil?
         do_finish(((end_time - @start_time).to_f * 1000.0).to_i)
@@ -107,7 +107,7 @@ module WavefrontOpentracing
 
     # Mark span as finished and send it via reporter.
     #
-    # @param duration_time [Integer] Duration time in seconds
+    # @param duration_time [Integer] Duration time in milliseconds
     # Thread.lock to be implemented
     def do_finish(duration_time)
       @update_lock.synchronize do

--- a/lib/wavefrontopentracing/span.rb
+++ b/lib/wavefrontopentracing/span.rb
@@ -30,8 +30,7 @@ module WavefrontOpentracing
     # @param tracer [Tracer] Tracer that create this span
     # @param operation_name [String] Operation Name
     # @param context [WavefrontSpanContext] Span Context
-    # @param start_time [Integer] an explicit Span start time as a unix
-    #   timestamp
+    # @param start_time [Time] an explicit Span start time as Time.now()
     # @param parents [UUID] List of UUIDs of parents span
     # @param follows [UUID] List of UUIDs of follows span
     # @param tags [Hash] List of tags
@@ -45,7 +44,7 @@ module WavefrontOpentracing
       @tracer = tracer
       @context = context
       @operation_name = operation_name
-      @start_time = start_time.to_i
+      @start_time = start_time
       @duration_time = 0
       @parents = parents
       @follows = follows
@@ -100,9 +99,9 @@ module WavefrontOpentracing
     # @param end_time [Integer] finish time, unix timestamp.
     def finish(end_time = nil)
       if !end_time.nil?
-        do_finish(end_time.to_i - @start_time)
+        do_finish(((end_time - @start_time).to_f * 1000.0).to_i)
       else
-        do_finish(Time.now.to_i - @start_time)
+        do_finish(((Time.now - @start_time).to_f * 1000.0).to_i)
       end
     end
 
@@ -157,7 +156,7 @@ module WavefrontOpentracing
     def log_kv(timestamp: Time.now, **args)
       args = {} if args.nil?
       record = {
-        timestamp: timestamp.to_i,
+        timestamp: (timestamp.to_f * 1000.0).to_i,
         fields: args.to_a.map do |key, value|
           { key.to_s => value.to_s }
         end

--- a/lib/wavefrontopentracing/tracer.rb
+++ b/lib/wavefrontopentracing/tracer.rb
@@ -43,7 +43,7 @@ module WavefrontOpentracing
     # @param references [List of Opentracing.Reference] (Optional)
     #   references that identify one or more parent `SpanContext`.
     # @param tags [Hash] (Optional) List of tags
-    # @param start_time [Integer] (Optional) Span start time as a unix timestamp
+    # @param start_time [Time] (Optional) Span start time as Time.now()
     # @param ignore_active_span [Boolean] An explicit flag that ignores
     #   the current active `Scope` and creates a root `Span`.
     # @return [Span] An already started Wavefront Span instance.
@@ -58,7 +58,7 @@ module WavefrontOpentracing
       baggage = {}
       tags ||= {}
       tags.update(@tags)
-      start_time ||= Time.now.to_i
+      start_time ||= Time.now
 
       parent = nil
       if !child_of.nil?
@@ -116,7 +116,7 @@ module WavefrontOpentracing
     # @param references [List of Opentracing.Reference] (Optional)
     #   references that identify one or more parent `SpanContext`.
     # @param tags [Hash] (Optional) List of tags
-    # @param start_time [Integer] (Optional) Span start time as a unix timestamp
+    # @param start_time [Time] (Optional) Span start time as Time.now()
     # @param ignore_active_span [Boolean] An explicit flag that ignores
     #   the current active `Scope` and creates a root `Span`.
     # @param finish_on_close [Boolean] Whether span should be automatically


### PR DESCRIPTION
If span duration is less than a second, it was showing it as `0`. Fixing this bug to show duration upto 1ms.